### PR TITLE
Also catch ignored file presence

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,5 @@
 /.git
 /.workspace-shell-dev
-/docker/.container_xauth
+/.container_xauth
 /HoloLens2-ResearchMode-Unity
 /unity

--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 # Project Ignores
 #
 /.workspace-shell-dev/
-/docker/.container_xauth
+/.container_xauth
 
 # This .gitignore file should be placed at the root of your Unity project directory
 #

--- a/angel-workspace-shell.sh
+++ b/angel-workspace-shell.sh
@@ -74,7 +74,7 @@ done
 SERVICE_NAME="${ARG_SERVICE_NAME:-${DEFAULT_SERVICE_NAME}}"
 
 # Create a permissions file for xauthority.
-XAUTH_DIR="${SCRIPT_DIR}/docker/.container_xauth"
+XAUTH_DIR="${SCRIPT_DIR}/.container_xauth"
 # Exporting to be used in replacement in docker-compose file.
 XAUTH_FILEPATH="$(mktemp "${XAUTH_DIR}/local-XXXXXX.xauth")"
 export XAUTH_FILEPATH

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -12,6 +12,7 @@ services:
       context: ..  # repo root
       dockerfile: docker/workspace-base-dev/Dockerfile
       cache_from:
+        - ${PTG_REGISTRY}/workspace-base-dev:latest
         - ${PTG_REGISTRY}/workspace-base-dev:${PTG_TAG}
     profiles:
       - build-only
@@ -29,6 +30,7 @@ services:
         PTG_REGISTRY:  # from .env file
         PTG_TAG:  # from .env file
       cache_from:
+        - ${PTG_REGISTRY}/workspace-build-dev:latest
         - ${PTG_REGISTRY}/workspace-build-dev:${PTG_TAG}
     profiles:
       - build-only
@@ -47,6 +49,7 @@ services:
     tty: true
     volumes:
       - /dev/shm:/dev/shm
+      # Host sharing
       - ../poetry.lock:/angel_workspace/poetry.lock
       - ../pyproject.toml:/angel_workspace/pyproject.toml
       - ../ros:/angel_workspace/src
@@ -63,6 +66,7 @@ services:
       # assume this file exists, should be created before running.
       - ${XAUTH_FILEPATH}:/tmp/.docker.xauth
     environment:
+      PYTHONDONTWRITEBYTECODE: "true"
       HISTFILE: /angel_workspace/stuff/bash_history
       CYCLONE_DDS_INTERFACE:  # from .env file or parent environment
       SETUP_WORKSPACE_INSTALL:  # from .env file or parent environment


### PR DESCRIPTION
Was finding that extraneous image rebuilds were happening because
ignored files were slipping into the source tree via use in container.
This adds extra protections to catch files modified that would impact
builds including `./docker/` and poetry files.