### PR TITLE
Fix Mixed Reality Capture video distortion

### DIFF
--- a/unity/Hello_World/Assets/MixedRealityToolkit.Generated/CustomProfiles/New MixedRealityCameraProfile.asset
+++ b/unity/Hello_World/Assets/MixedRealityToolkit.Generated/CustomProfiles/New MixedRealityCameraProfile.asset
@@ -27,7 +27,7 @@ MonoBehaviour:
     componentName: XR SDK Windows Mixed Reality Camera Settings
     priority: 0
     runtimePlatform: 9
-    settingsProfile: {fileID: 11400000, guid: b8be5b71c8e0a254c83b691d62a79ff5, type: 2}
+    settingsProfile: {fileID: 11400000, guid: 08d6cd81f7104b74ba5d606109e3c6f2, type: 2}
   - componentType:
       reference: Microsoft.MixedReality.Toolkit.XRSDK.GenericXRSDKCameraSettings,
         Microsoft.MixedReality.Toolkit.Providers.XRSDK

--- a/unity/Hello_World/Assets/MixedRealityToolkit.Generated/CustomProfiles/PTG Camera Profile.asset
+++ b/unity/Hello_World/Assets/MixedRealityToolkit.Generated/CustomProfiles/PTG Camera Profile.asset
@@ -1,0 +1,18 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a794cc45c30a79b4da55bfd426876503, type: 3}
+  m_Name: PTG Camera Profile
+  m_EditorClassIdentifier: 
+  isCustomProfile: 1
+  renderFromPVCameraForMixedRealityCapture: 1
+  reprojectionMethod: 0
+  readingModeEnabled: 0

--- a/unity/Hello_World/Assets/MixedRealityToolkit.Generated/CustomProfiles/PTG Camera Profile.asset.meta
+++ b/unity/Hello_World/Assets/MixedRealityToolkit.Generated/CustomProfiles/PTG Camera Profile.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 08d6cd81f7104b74ba5d606109e3c6f2
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Enables "render from PV camera" for mixed reality capture. By default this setting is not enabled and can cause distortion issues when MRC video capture is running.

https://docs.microsoft.com/en-us/windows/mixed-reality/develop/advanced-concepts/mixed-reality-capture-overview#render-from-the-pv-camera-opt-in)](https://docs.microsoft.com/en-us/windows/mixed-reality/develop/advanced-concepts/mixed-reality-capture-overview#render-from-the-pv-camera-opt-in
