### PR TITLE
Add QueryImageSize service

### DIFF
--- a/ros/angel_msgs/CMakeLists.txt
+++ b/ros/angel_msgs/CMakeLists.txt
@@ -44,6 +44,7 @@ set( message_files
 set( service_files
   srv/QueryAllObjects3d.srv
   srv/QueryTaskGraph.srv
+  srv/QueryImageSize.srv
   )
 rosidl_generate_interfaces( ${PROJECT_NAME} ${message_files} ${service_files}
   DEPENDENCIES builtin_interfaces std_msgs geometry_msgs shape_msgs vision_msgs

--- a/ros/angel_msgs/srv/QueryImageSize.srv
+++ b/ros/angel_msgs/srv/QueryImageSize.srv
@@ -1,0 +1,4 @@
+# Query the current image dimensions
+---
+int16 image_width
+int16 image_height

--- a/ros/angel_msgs/srv/QueryImageSize.srv
+++ b/ros/angel_msgs/srv/QueryImageSize.srv
@@ -1,4 +1,6 @@
 # Query the current image dimensions
+# Note that image_width and image_height may be -1 if an image has not been
+# received by the image_converter node yet
 ---
 int16 image_width
 int16 image_height

--- a/ros/angel_system_nodes/angel_system_nodes/object_detector.py
+++ b/ros/angel_system_nodes/angel_system_nodes/object_detector.py
@@ -12,6 +12,7 @@ from smqtk_core.configuration import from_config_dict
 from smqtk_detection.interfaces.detect_image_objects import DetectImageObjects
 
 from angel_msgs.msg import ObjectDetection2dSet
+from angel_msgs.srv import QueryImageSize
 from angel_utils.conversion import from_detect_image_objects_result
 
 
@@ -48,8 +49,17 @@ class ObjectDetector(Node):
             1
         )
 
+        # Start a service to allow other nodes to get the current image size
+        self._image_size_service = self.create_service(QueryImageSize,
+                                                       "query_image_size",
+                                                       self.query_image_size_callback)
+
         self._frames_recvd = 0
         self._prev_time = -1
+
+        # These are populated from the image message and used for the image size service
+        self._image_width = -1
+        self._image_height = -1
 
         # instantiate detector from the given config
         with open(self._detector_config, "r") as f:
@@ -68,6 +78,9 @@ class ObjectDetector(Node):
             log.info(f"Frames rcvd: {self._frames_recvd}")
             self._frames_recvd = 0
             self._prev_time = time.time()
+
+        self._image_width = image.width
+        self._image_height = image.height
 
         # convert ROS Image message to CV2
         rgb_image = BRIDGE.imgmsg_to_cv2(image, desired_encoding="rgb8")
@@ -97,6 +110,14 @@ class ObjectDetector(Node):
 
         self._publisher.publish(det_set_msg)
 
+    def query_image_size_callback(self, request, response):
+        """
+        Populate the `QueryImageSize` response with current image dimensions
+        and return it.
+        """
+        response.image_width = self._image_width
+        response.image_height = self._image_height
+        return response
 
 def main():
     rclpy.init()

--- a/ros/angel_system_nodes/angel_system_nodes/spatial_mapper.py
+++ b/ros/angel_system_nodes/angel_system_nodes/spatial_mapper.py
@@ -14,6 +14,7 @@ from angel_msgs.msg import (
     SpatialMesh,
     HeadsetPoseData
 )
+from angel_msgs.srv import QueryImageSize
 from angel_utils.conversion import to_confidence_matrix
 from geometry_msgs.msg import Point
 
@@ -79,12 +80,38 @@ class SpatialMapSubscriber(Node):
 
         self.poses = []
 
-        # TODO: get this from a ROS message?
-        self.image_height = 1080
-        self.image_width = 1920
+        # default image dimensions used if we fail to get the current image size
+        self.image_height = 720
+        self.image_width = 1280
+
+        # attempt to get the current image size from the object detector
+        self.image_size_client = self.create_client(QueryImageSize, 'query_image_size')
+        while not self.image_size_client.wait_for_service(timeout_sec=1.0):
+            log.info("Waiting for image size service...")
+
+        r = self.send_image_size_request()
+        log.info(f"Image size response {r}")
+        if r.image_width <= 0 or r.image_height <= 0:
+            log.warn("Invalid image dimensions."
+                     + "Make sure the object detector node is running and receiving frames")
+            log.warn(f"Using default image dimensions {self.image_width}x{self.image_height}")
+        else:
+            self.image_height = r.image_height
+            self.image_width = r.image_width
 
         log = self.get_logger()
         #log.set_level(10)
+
+
+    def send_image_size_request(self):
+        """
+        Sends a `QueryImageSize` request message to the QueryImageSize
+        service running in the object detector node.
+        """
+        self.req = QueryImageSize.Request()
+        self.future = self.image_size_client.call_async(self.req)
+        rclpy.spin_until_future_complete(self, self.future)
+        return self.future.result()
 
 
     def spatial_map_callback(self, msg):

--- a/ros/angel_system_nodes/angel_system_nodes/spatial_mapper.py
+++ b/ros/angel_system_nodes/angel_system_nodes/spatial_mapper.py
@@ -92,8 +92,8 @@ class SpatialMapSubscriber(Node):
             log.warn("Invalid image dimensions."
                      + " Make sure the image converter node is running and receiving frames")
 
-            r = self.send_image_size_request()
             time.sleep(1)
+            r = self.send_image_size_request()
 
         log.info(f"Received valid image dimensions. Current size: {r.image_width}x{r.image_height}")
         self.image_height = r.image_height


### PR DESCRIPTION
Add a ROS service so that the spatial mapper node can request the current image dimensions that are being handled.

This fixes a bug where the spatial mapper's assumed image dimensions (1920x1080) did not match the actual size (1280x720) of the images being handled, causing the boxes to appear in the wrong 3d locations.