### PR TITLE
Fix package.xml file isolation

### DIFF
--- a/docker/workspace-build/Dockerfile
+++ b/docker/workspace-build/Dockerfile
@@ -61,7 +61,11 @@ ENV ANGEL_WORKSPACE_DIR="${ANGEL_WORKSPACE_DIR}"
 #
 FROM base AS tmp_package_files
 COPY ./ros "${ANGEL_WORKSPACE_DIR}"/src
-RUN find "${ANGEL_WORKSPACE_DIR}"/src -type f \! -name "package.xml" -print | xargs rm
+RUN mkdir "${ANGEL_WORKSPACE_DIR}"/tmp \
+ && (find "${ANGEL_WORKSPACE_DIR}"/src -type f -name 'package.xml' -print | xargs -n1 -I{} cp --parents {} "${ANGEL_WORKSPACE_DIR}"/tmp) \
+ && rm -r "${ANGEL_WORKSPACE_DIR}"/src \
+ && mv "${ANGEL_WORKSPACE_DIR}"/tmp/"${ANGEL_WORKSPACE_DIR}"/src "${ANGEL_WORKSPACE_DIR}"/ \
+ && rm -r "${ANGEL_WORKSPACE_DIR}"/tmp
 
 #
 # Build our workspace


### PR DESCRIPTION
The previous method was not removing empty directories that resulted
from removing files. This caused excessive rebuild's of package
dependencies if any directory structure in the workspace was changed.
This adjusted isolation method is more explicit in retaining the target
files instead of trying to be fancy with inversion.

@joshanderson-kw Please just sanity check me here.