### PR TITLE
Add AngelARUI gameobject to arui_engineering scene

### DIFF
--- a/unity/ARUI/Assets/MixedRealityToolkit.Generated/ARUI/CustomProfiles/AngelMixedRealityHandTrackingProfile.asset
+++ b/unity/ARUI/Assets/MixedRealityToolkit.Generated/ARUI/CustomProfiles/AngelMixedRealityHandTrackingProfile.asset
@@ -13,13 +13,9 @@ MonoBehaviour:
   m_Name: AngelMixedRealityHandTrackingProfile
   m_EditorClassIdentifier: 
   isCustomProfile: 1
-  jointPrefab: {fileID: 1955475817299902, guid: 6a3f88d2571cd234a86d95ee5856b9ec,
-    type: 3}
-  palmPrefab: {fileID: 6797406804172968804, guid: 750bdc3344567a447960aae3eda2b462,
-    type: 3}
-  fingertipPrefab: {fileID: 7094064642998883381, guid: b37dde41a983d664c8a09a91313733e7,
-    type: 3}
-  handMeshPrefab: {fileID: 1887883006053652, guid: a86f479797fea8f4189f924b3b6ad979,
-    type: 3}
+  jointPrefab: {fileID: 1955475817299902, guid: 6a3f88d2571cd234a86d95ee5856b9ec, type: 3}
+  palmPrefab: {fileID: 6797406804172968804, guid: 750bdc3344567a447960aae3eda2b462, type: 3}
+  fingertipPrefab: {fileID: 7094064642998883381, guid: b37dde41a983d664c8a09a91313733e7, type: 3}
+  handMeshPrefab: {fileID: 1887883006053652, guid: a86f479797fea8f4189f924b3b6ad979, type: 3}
   handMeshVisualizationModes: 0
-  handJointVisualizationModes: -1
+  handJointVisualizationModes: 0

--- a/unity/ARUI/Assets/MixedRealityToolkit.Generated/CustomProfiles/PTG MixedRealityToolkitConfigurationProfile.asset
+++ b/unity/ARUI/Assets/MixedRealityToolkit.Generated/CustomProfiles/PTG MixedRealityToolkitConfigurationProfile.asset
@@ -21,7 +21,7 @@ MonoBehaviour:
     reference: Microsoft.MixedReality.Toolkit.CameraSystem.MixedRealityCameraSystem,
       Microsoft.MixedReality.Toolkit.Services.CameraSystem
   enableInputSystem: 1
-  inputSystemProfile: {fileID: 11400000, guid: 0400f49e8da95854fabf52bb98fe53d4, type: 2}
+  inputSystemProfile: {fileID: 11400000, guid: dafc2d6330d4f3a4eb928e871bc6b100, type: 2}
   inputSystemType:
     reference: Microsoft.MixedReality.Toolkit.Input.MixedRealityInputSystem, Microsoft.MixedReality.Toolkit.Services.InputSystem
   enableBoundarySystem: 1

--- a/unity/ARUI/Assets/Scenes/arui_engineering.unity
+++ b/unity/ARUI/Assets/Scenes/arui_engineering.unity
@@ -289,6 +289,9 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   imageTopicName: PVFramesNV12
   headsetPoseTopicName: HeadsetPoseData
+  targetVideoHeight: 720
+  targetVideoWidth: 1280
+  targetVideoFrameRate: 30
 --- !u!4 &802567262
 Transform:
   m_ObjectHideFlags: 0
@@ -833,6 +836,51 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 10
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1332611131
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1332611133}
+  - component: {fileID: 1332611132}
+  m_Layer: 0
+  m_Name: AngelARUI
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1332611132
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1332611131}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 81980225b99f44f3195a30bcc5317c16, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  mainCamera: {fileID: 0}
+  showARUIDebugMessages: 1
+--- !u!4 &1332611133
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1332611131}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 13
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1357314903
 GameObject:
   m_ObjectHideFlags: 0
@@ -908,6 +956,49 @@ Transform:
   - {fileID: 1106259186}
   m_Father: {fileID: 0}
   m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1485002824
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1485002826}
+  - component: {fileID: 1485002825}
+  m_Layer: 0
+  m_Name: AngelARUITest
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1485002825
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1485002824}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3d674ff7b4a94e04d9a5dad6a0718a37, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!4 &1485002826
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1485002824}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -0.025709912, y: 0.03955535, z: 1.0482492}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 14
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1676318194
 GameObject:

--- a/unity/ARUI/ProjectSettings/EditorBuildSettings.asset
+++ b/unity/ARUI/ProjectSettings/EditorBuildSettings.asset
@@ -11,10 +11,10 @@ EditorBuildSettings:
   - enabled: 0
     path: Assets/Samples/Mixed Reality Toolkit Examples/2.7.2/Demos - HandTracking/Scenes/HandInteractionExamples.unity
     guid: 3dd4a396b5225f8469b9a1eb608bfa57
-  - enabled: 0
+  - enabled: 1
     path: Assets/Scenes/arui_engineering.unity
     guid: c5ee4deb1bb4af74f8971a715e5ce3fc
-  - enabled: 1
+  - enabled: 0
     path: Assets/Scenes/Angel3DUI_example.unity
     guid: 9e7845e35551e844285b5764bb40ce18
   m_configObjects:


### PR DESCRIPTION
Add the `AngelARUI` script and `TapTestData` script to the arui_engineering scene. Modify the PTG MRTK configuration profile to use the `AngelMRTKInputSystemProfile` for speech/gesture recognition.

Engineering logging panels are still present. Wasn't sure if we wanted to remove those just yet.