### PR TITLE
Add done step back

### DIFF
--- a/ros/angel_system_nodes/angel_system_nodes/task_monitor.py
+++ b/ros/angel_system_nodes/angel_system_nodes/task_monitor.py
@@ -115,6 +115,12 @@ class CoffeeDemoTask():
                 self.steps.append({'name': task_name})
                 self.uids[task_name] = str(uuid.uuid4())
 
+        # Manually add the finish step
+        self.task_graph_steps.append("Done")
+        self.task_graph_step_levels.append(0)
+        self.steps.append({'name': 'Done'})
+        self.uids['Done'] = str(uuid.uuid4())
+
         # Create the transitions between steps, assuming linear steps
         # TODO: use the step index in the task steps file to decide
         # the destination step


### PR DESCRIPTION
Removing the done step caused an error when the last activity tried to trigger.

There doesn't seem to be a good way in the ARUI to indicate that the very last step has been completed, so adding this back in for now.