### PR TITLE
Add `tmux` dir to list causing warning

### DIFF
--- a/angel-docker-build.sh
+++ b/angel-docker-build.sh
@@ -54,6 +54,7 @@ warn_build_spaces=(
   "${SCRIPT_DIR}/pyproject.toml"
   "${SCRIPT_DIR}/poetry.lock"
   "${SCRIPT_DIR}/angel_system"
+  "${SCRIPT_DIR}/tmux"
 )
 git_status="$(git status --porcelain "${warn_build_spaces[@]}")"
 # Check if there are ignored files in the workspace that should not be there.


### PR DESCRIPTION
Build script will now additionally look for modifications in the `tmux` directory and required a forced build if there are any found.