### PR TITLE
Add a activity label query service for activity detector to satisfy

### DIFF
--- a/ros/angel_msgs/CMakeLists.txt
+++ b/ros/angel_msgs/CMakeLists.txt
@@ -44,6 +44,7 @@ set( message_files
   msg/VisionBoundingBox3d.msg
   )
 set( service_files
+  srv/QueryActivityLabels.srv
   srv/QueryAllObjects3d.srv
   srv/QueryTaskGraph.srv
   srv/QueryImageSize.srv

--- a/ros/angel_msgs/srv/QueryActivityLabels.srv
+++ b/ros/angel_msgs/srv/QueryActivityLabels.srv
@@ -1,0 +1,10 @@
+# Query from an activity detection and classification node the labels it
+# predicts.
+# Labels are provided in an array in a deterministic order such that the order
+# is maintained across multiple runs of the activity detector when
+# parameterized the same.
+# Due to this order determinism, the integer index of a specific label may be
+# considered it's integer ID.
+
+---
+string[] label_array


### PR DESCRIPTION
A quick modification, based on an offline conversation, that adds to the activity detection service the ability to communicate the labels that it can predict.