### PR TITLE
Add stub activity classifier mode to UHO detector node

### DIFF
--- a/angel_system/eval/gt_predict.py
+++ b/angel_system/eval/gt_predict.py
@@ -1,0 +1,80 @@
+from typing import (
+    List,
+    Tuple,
+)
+
+import pandas
+import torch
+
+from angel_system.eval.support_functions import time_from_name
+
+
+# TODO: What is the best place for this function?
+def gt_predict(
+    gt_file: str,
+    frame_set_start_stamp: float,
+    frame_set_end_stamp: float
+) -> Tuple[Tuple[torch.Tensor, torch.Tensor], List[str]]:
+    """
+    Creates a simulated classifier prediction given the ground truth annotation
+    file and the frame timestamps. The frame stamps are used to determine which
+    activity was being performed in the ground truth file.
+
+    The return type is consistent with the UHO's predict function.
+
+    :param gt_file: string path for the ground truth annotations to use. It is
+        expected that this is a feather file.
+    :param frame_set_start_stamp: The start time in seconds for this frame
+        window.
+    :param frame_set_end_stamp: The end time in seconds for this frame window.
+
+    :return: A tuple consisting of two elements:
+            0: Classifier results: A tuple consisting of a [1 x n_classes] tensor
+               representing the classifier's confidence for each class and a tensor
+               containing the index of the max confidence in the confidence tensor.
+            1: A list of length n_classes for mapping the classifier's confidence
+               indices to class strings.
+    """
+    gt = pandas.read_feather(gt_file)
+
+    # Create list of classifier classes
+    anno_labels = gt['class'].tolist()
+    classes = list(dict.fromkeys(anno_labels))
+    classes.insert(0, "Background")
+
+    start_frames = gt['start_frame'].tolist()
+    end_frames = gt['end_frame'].tolist()
+
+    start_frames_sec = [time_from_name(f) for f in start_frames]
+    end_frames_sec = [time_from_name(f) for f in end_frames]
+
+    # Find which window the given frame stamps line up with
+    confidences = torch.zeros(len(classes))
+    classifier_label_idx = 0
+    activity = "Background"
+    for anno_label, start, end in zip(anno_labels, start_frames_sec, end_frames_sec):
+        if frame_set_start_stamp >= start and frame_set_end_stamp <= end:
+            classifier_label_idx = classes.index(anno_label)
+            activity = anno_label
+            break
+        elif (
+            frame_set_start_stamp < start and
+            start <= frame_set_end_stamp <= end
+        ):
+            # Frame window end frame is within this annotation window
+            classifier_label_idx = classes.index(anno_label)
+            activity = anno_label
+            break
+        elif (
+            start <= frame_set_start_stamp <= end and
+            frame_set_end_stamp > end
+        ):
+            # Frame window start frame is within this annotation window
+            classifier_label_idx = classes.index(anno_label)
+            activity = anno_label
+            break
+
+    confidences[classifier_label_idx] = 1.0
+    class_idx = torch.tensor(classifier_label_idx)
+
+    return (confidences, class_idx), classes

--- a/angel_system/eval/gt_predict.py
+++ b/angel_system/eval/gt_predict.py
@@ -1,3 +1,4 @@
+import time
 from typing import (
     List,
     Tuple,
@@ -13,12 +14,14 @@ from angel_system.eval.support_functions import time_from_name
 def gt_predict(
     gt_file: str,
     frame_set_start_stamp: float,
-    frame_set_end_stamp: float
+    frame_set_end_stamp: float,
+    predict_time: float = 1.0
 ) -> Tuple[Tuple[torch.Tensor, torch.Tensor], List[str]]:
     """
     Creates a simulated classifier prediction given the ground truth annotation
     file and the frame timestamps. The frame stamps are used to determine which
-    activity was being performed in the ground truth file.
+    activity was being performed in the ground truth file. By default, there
+    is an artificial delay to simulate the classifier's computation time.
 
     The return type is consistent with the UHO's predict function.
 
@@ -27,6 +30,8 @@ def gt_predict(
     :param frame_set_start_stamp: The start time in seconds for this frame
         window.
     :param frame_set_end_stamp: The end time in seconds for this frame window.
+    :param predict_time: How long to delay returning the result to simulate the
+        computation time the classifier would take.
 
     :return: A tuple consisting of two elements:
             0: Classifier results: A tuple consisting of a [1 x n_classes] tensor
@@ -76,5 +81,7 @@ def gt_predict(
 
     confidences[classifier_label_idx] = 1.0
     class_idx = torch.tensor(classifier_label_idx)
+
+    time.sleep(predict_time)
 
     return (confidences, class_idx), classes

--- a/angel_system/utils/activity_classification.py
+++ b/angel_system/utils/activity_classification.py
@@ -10,7 +10,6 @@ import torch
 from angel_system.eval.support_functions import time_from_name
 
 
-# TODO: What is the best place for this function?
 def gt_predict(
     gt_file: str,
     frame_set_start_stamp: float,

--- a/ros/angel_system_nodes/angel_system_nodes/uho_activity_detector.py
+++ b/ros/angel_system_nodes/angel_system_nodes/uho_activity_detector.py
@@ -25,7 +25,7 @@ from angel_msgs.msg import (
     ObjectDetection2dSet
 )
 
-from angel_system.eval.gt_predict import gt_predict
+from angel_system.utils.activity_classification import gt_predict
 from angel_system.uho.predict import get_uho_classifier, predict
 from angel_system.uho.deprecated_src.data_helper import create_batch
 from angel_system.utils.matching import descending_match_with_tolerance


### PR DESCRIPTION
Add `gt_file` param to the UHO activity detector node. If no file is provided, the node operates as usual running the activity classifier. If a a ground truth file is provided, the node uses `gt_predict` instead of calling the classifier predict function.

Tested on one Alex's recordings and it seems to match up pretty well.
