### PR TITLE
Multiple gt pred pairs + CM update

### DIFF
--- a/angel_system/ptg_eval/activity_classification/evaluate_activity.py
+++ b/angel_system/ptg_eval/activity_classification/evaluate_activity.py
@@ -1,7 +1,11 @@
-from pathlib import Path
 import argparse
-
 import logging
+from pathlib import Path
+from typing import List
+from typing import Optional
+
+import numpy as np
+import numpy.typing as npt
 
 from angel_system.ptg_eval.common.load_data import (
     activities_from_dive_csv,
@@ -13,7 +17,7 @@ from angel_system.ptg_eval.activity_classification.visualization import EvalVisu
 from angel_system.ptg_eval.activity_classification.compute_scores import EvalMetrics
 
 
-logging.basicConfig(level = logging.INFO)
+logging.basicConfig(level=logging.INFO)
 log = logging.getLogger("ptg_eval_activity")
 
 
@@ -21,20 +25,60 @@ def run_eval(args):
     output_dir = Path(args.output_dir)
     output_dir.mkdir(parents=True, exist_ok=True)
 
-    # labels, gt, detections = load_from_file(args.activity_gt, args.extracted_activity_detections)
-    gt = activities_from_dive_csv(args.activity_gt)
-    labels, detections = activities_from_ros_export_json(args.extracted_activity_detections)
+    time_window = args.time_window
+    uncertainty_pad = args.uncertainty_pad
 
-    # Make gt/detections pd.DataFrame instance to be consistent with downstream
-    # implementation.
-    gt = activities_as_dataframe(gt)
-    detections = activities_as_dataframe(detections)
+    # TODO: For multiple gt/pred pairs, loop over the following 3 sections,
+    #       vertically stacking the `gt_true_mask` and `dets_per_valid_time_w`
+    #       matrices.
+    # TODO: Assert that the labels returned for each pair is equal.
+    gt_true_mask: Optional[npt.NDArray] = None
+    dets_per_valid_time_w: Optional[npt.NDArray] = None
+    labels: Optional[List[str]] = None
+    for i, (gt_fpath, pred_fpath) in enumerate(args.activity_gt_pred_pair):
+        log.info(f"Loading data from pair {i}")
+        gt = activities_from_dive_csv(gt_fpath.as_posix())
+        l_labels, detections = activities_from_ros_export_json(pred_fpath.as_posix())
+        if labels is None:
+            labels = l_labels
+        else:
+            assert labels == l_labels, (
+                f"Subsequent gt/pred pair has disjoint label sets/orders. "
+                f"{labels} != {l_labels}"
+            )
 
-    gt_true_mask, dets_per_valid_time_w, time_windows = (
-        discretize_data_to_windows(labels, gt, detections,
-                                   args.time_window, args.uncertainty_pad)
-    )
-    
+        # Make gt/detections pd.DataFrame instance to be consistent with downstream
+        # implementation.
+        gt = activities_as_dataframe(gt)
+        detections = activities_as_dataframe(detections)
+
+        # Local masks for this specific file pair
+        l_gt_true_mask, l_dets_per_valid_time_w, l_time_windows = (
+            discretize_data_to_windows(labels, gt, detections,
+                                       time_window, uncertainty_pad)
+        )
+
+        # for each pair, output separate activity window plots
+        log.info("Visualizing this detection set against respective "
+                 "ground-truth.")
+        pair_out_dir = output_dir / f"pair_{gt_fpath.stem}_{pred_fpath.stem}"
+        vis = EvalVisualization(labels, None, None, output_dir=pair_out_dir)
+        vis.plot_activities_confidence(gt=gt, dets=detections)
+
+        # Stack with global set
+        if gt_true_mask is None:
+            gt_true_mask = l_gt_true_mask
+        else:
+            gt_true_mask = np.concatenate([gt_true_mask, l_gt_true_mask])
+        if dets_per_valid_time_w is None:
+            dets_per_valid_time_w = l_dets_per_valid_time_w
+        else:
+            dets_per_valid_time_w = np.concatenate([dets_per_valid_time_w, l_dets_per_valid_time_w])
+
+    assert labels is not None, "No consistent label set loaded."
+    assert gt_true_mask is not None, "No ground truth loaded."
+    assert dets_per_valid_time_w is not None, "No predictions loaded"
+
     # ============================
     # Metrics
     # ============================
@@ -47,7 +91,6 @@ def run_eval(args):
     # Plot
     # ============================
     vis = EvalVisualization(labels, gt_true_mask, dets_per_valid_time_w, output_dir=output_dir)
-    vis.plot_activities_confidence(gt=gt, dets=detections)
     vis.plot_pr_curve()
     vis.plot_roc_curve()
     vis.confusion_mat()
@@ -58,14 +101,16 @@ def run_eval(args):
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument(
-        "--activity_gt",
-        type=str,
-        help="CSV file containing the ground truth annotations as exported from DIVE."
-    )
-    parser.add_argument(
-        "--extracted_activity_detections",
-        type=str,
-        help="JSON file containing the activity detections from an extracted ROS2 bag"
+        "--gt-pred-pair",
+        help="Specification of a pair of filepaths that refer to the "
+             "ground-truth CSV file and prediction result JSON file, "
+             "respectively. This option may be repeated any number of times "
+             "for independent pairs.",
+        dest="activity_gt_pred_pair",
+        type=Path,
+        nargs=2,
+        default=[],
+        action="append",
     )
     parser.add_argument(
         "--time_window",

--- a/angel_system/ptg_eval/activity_classification/evaluate_activity.py
+++ b/angel_system/ptg_eval/activity_classification/evaluate_activity.py
@@ -28,10 +28,7 @@ def run_eval(args):
     time_window = args.time_window
     uncertainty_pad = args.uncertainty_pad
 
-    # TODO: For multiple gt/pred pairs, loop over the following 3 sections,
-    #       vertically stacking the `gt_true_mask` and `dets_per_valid_time_w`
-    #       matrices.
-    # TODO: Assert that the labels returned for each pair is equal.
+    # Loop over gt/pred pairs, gathering input data for eval.
     gt_true_mask: Optional[npt.NDArray] = None
     dets_per_valid_time_w: Optional[npt.NDArray] = None
     labels: Optional[List[str]] = None

--- a/angel_system/ptg_eval/activity_classification/visualization.py
+++ b/angel_system/ptg_eval/activity_classification/visualization.py
@@ -3,6 +3,7 @@ import numpy as np
 from pathlib import Path
 import os
 
+import seaborn as sn
 from sklearn.metrics import PrecisionRecallDisplay, precision_recall_curve, average_precision_score
 from sklearn.metrics import roc_curve, auc
 from sklearn.metrics import confusion_matrix, ConfusionMatrixDisplay
@@ -200,19 +201,26 @@ class EvalVisualization:
         """
         Plot a confusion matrix of size (number of labels x number of labels)
         """
+
         log.debug("Plotting confusion matrix")
         plt.rcParams.update({'font.size': 55})
         fig, ax = plt.subplots(figsize=(100, 100))
 
+        n_classes = len(self.labels)
+        label_vec = np.arange(n_classes)
         true_idxs = np.where(self.gt_true_mask==True)[1]
         pred_idxs = np.argmax(self.window_class_scores, axis=1)
 
-        cm = confusion_matrix(true_idxs, pred_idxs, labels=range(len(self.labels)))
-        disp = ConfusionMatrixDisplay(confusion_matrix=cm,
-                                      display_labels=self.labels)
-        disp.plot(ax=ax, xticks_rotation=90)
-        
-        plt.tight_layout()
+        cm = confusion_matrix(true_idxs, pred_idxs,
+                              labels=label_vec,
+                              normalize="true")
+
+        sn.heatmap(cm, annot=True, fmt=".2f", ax=ax)
+        ax.set(
+            title="Confusion Matrix",
+            xlabel="Predicted Label",
+            ylabel="True Label",
+        )
         fig.savefig(f"{self.output_dir}/confusion_mat.png", pad_inches=5)
         plt.close(fig)
 

--- a/docs/evaluation.rst
+++ b/docs/evaluation.rst
@@ -62,9 +62,14 @@ Extract activity detections from the new ros bag
         -p extract_depth_images:="False" \
         -p extract_depth_head_pose_data:="False"
 
-Run eval
-########
+Running the evaluation tool
+###########################
 ``$ ptg_eval_activity <optional flags>``
+
+The tool must take in one or more ground-truth / prediction file pairs.
+It is generally expected that we should have such an evaluable pair for a
+single recording.
+Pairs are provided via the ``--gt-pred-pair`` option.
 
 The evaluation tool should be run with a ``--time_window`` option that is
 non-trivially smaller than predicted activity time windows.
@@ -75,8 +80,9 @@ temporal bounds.
 E.g.::
 
     $ poetry run ptg_eval_activity \
-            --activity_gt labels_test_v1.4.csv \
-            --extracted_activity_detections sample_dets.json \
+            --gt-pred-pair truth_1.csv predictions_1.json \
+            --gt-pred-pair truth_2.csv predictions_2.json \
+            --gt-pred-pair truth_3.csv predictions_3.json \
             --time_window 0.1 \
             --uncertainty_pad 0.05 \
             --output_dir ./eval_output/

--- a/poetry.lock
+++ b/poetry.lock
@@ -1396,6 +1396,24 @@ python-versions = ">=3.8,<3.11"
 numpy = ">=1.17.3,<1.25.0"
 
 [[package]]
+name = "seaborn"
+version = "0.12.1"
+description = "Statistical data visualization"
+category = "main"
+optional = false
+python-versions = ">=3.7"
+
+[package.dependencies]
+matplotlib = ">=3.1,<3.6.1 || >3.6.1"
+numpy = ">=1.17"
+pandas = ">=0.25"
+
+[package.extras]
+dev = ["flake8", "mypy", "pandas-stubs", "pre-commit", "pytest", "pytest-cov", "pytest-xdist"]
+docs = ["ipykernel", "nbconvert", "numpydoc", "pydata_sphinx_theme (==0.10.0rc2)", "pyyaml", "sphinx-copybutton", "sphinx-design", "sphinx-issues"]
+stats = ["scipy (>=1.3)", "statsmodels (>=0.10)"]
+
+[[package]]
 name = "setuptools"
 version = "59.5.0"
 description = "Easily download, build, install, upgrade, and uninstall Python packages"
@@ -2121,7 +2139,7 @@ testing = ["func-timeout", "jaraco.itertools", "pytest (>=6)", "pytest-black (>=
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8,<3.10"
-content-hash = "7f2b5c3c33011cce93201d1997d6a7301d5fba4a919e02c960c80c322b8aedb5"
+content-hash = "25b395e08dd321d93e35dce606cae60ed159dc966b6bbf9eb035f788cb252d91"
 
 [metadata.files]
 absl-py = [
@@ -3488,6 +3506,10 @@ scipy = [
     {file = "scipy-1.8.0-cp39-cp39-win32.whl", hash = "sha256:3d573228c10a3a8c32b9037be982e6440e411b443a6267b067cac72f690b8d56"},
     {file = "scipy-1.8.0-cp39-cp39-win_amd64.whl", hash = "sha256:bb7088e89cd751acf66195d2f00cf009a1ea113f3019664032d9075b1e727b6c"},
     {file = "scipy-1.8.0.tar.gz", hash = "sha256:31d4f2d6b724bc9a98e527b5849b8a7e589bf1ea630c33aa563eda912c9ff0bd"},
+]
+seaborn = [
+    {file = "seaborn-0.12.1-py3-none-any.whl", hash = "sha256:a9eb39cba095fcb1e4c89a7fab1c57137d70a715a7f2eefcd41c9913c4d4ed65"},
+    {file = "seaborn-0.12.1.tar.gz", hash = "sha256:bb1eb1d51d3097368c187c3ef089c0288ec1fe8aa1c69fb324c68aa1d02df4c1"},
 ]
 setuptools = [
     {file = "setuptools-59.5.0-py3-none-any.whl", hash = "sha256:6d10741ff20b89cd8c6a536ee9dc90d3002dec0226c78fb98605bfb9ef8a7adf"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ pyarrow = "^9.0.0"  # for feature file support
 pynput = "^1.7.6"
 pytorchvideo = "^0.1.5"
 scikit-learn = "^1.1.2"
+seaborn = "^0.12.1"
 simpleaudio = "^1.0.4"
 smqtk-detection = ">=0.19.0"
 timm = "^0.5.4"


### PR DESCRIPTION
Change activity eval CLI to be able to take in multiple gt/pred file pairs and aggregate metrics/confusion-matrix/PR/ROC outputs over all inputs. Maintains per-pair output of pred-over-GT bar plot output.

Also updated confusion matrix output as discussed. Adding use of seaborn.