### PR TITLE
README/Unity Tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,10 @@ HL2SS plugin - 1.0.15 - https://github.com/jdibenes/hl2ss
 ## First time build/deploy instructions
 
 1) Open the unity/ARUI project with Unity Hub.
-2) Open the demo scene in the Unity editor (unity\ARUI\Assets\my_scene).
-3) Modify the default project build settings (``File -> Build Settings...``).  
+2) Open the arui_engineering scene in the Unity editor (unity\ARUI\Assets\my_scene).
+3) Modify the default project build settings (``File -> Build Settings...``).
+   - Ensure the "Scenes/arui_engineering" scene is checked for inclusion in the build
+     (others may be unchecked).
    - Under the Universal Windows Platform tab
      - Target Device = HoloLens  
      - Architecture = ARM64  
@@ -43,9 +45,8 @@ HL2SS plugin - 1.0.15 - https://github.com/jdibenes/hl2ss
 7) Open the .sln file with Visual Studio.  
 8) In Visual Studio, switch ``Solution Configurations`` to Release and ``Solution Platforms`` to ARM64.  
 9) Open the project properties window (In the ``Solution Explorer`` pane, right-click ``Angel_ARUI`` and select ``Properties``) and switch to the ``Configurations -> Debugging`` tab. Enter the IP address of your HoloLens in the Machine Name field.
-10) Modify the ``Package.appxmanifest`` per the README in HoloLens2-ResearchMode-Unity/  
-11) Deploy the app to the Hololens by clicking ``Build -> Deploy Solution``
-12) After deployment completes, open the Windows menu in the Hololens and select All Apps, and then click on the Angel_ARUI application.
+10) Deploy the app to the Hololens by clicking ``Build -> Deploy Solution``
+11) After deployment completes, open the Windows menu in the Hololens and select All Apps, and then click on the Angel_ARUI application.
 
 ## ROS Unity Setup
 ### ROS IP configuration

--- a/unity/ARUI/Assets/Scripts/ARUI/AngelARUI.cs
+++ b/unity/ARUI/Assets/Scripts/ARUI/AngelARUI.cs
@@ -2,7 +2,7 @@ using DilmerGames.Core.Singletons;
 using UnityEngine;
 using UnityEngine.Events;
 using RosMessageTypes.Angel;
-using System.Diagnostics.Eventing.Reader;
+//using System.Diagnostics.Eventing.Reader;
 using System;
 using System.Collections;
 

--- a/unity/ARUI/Assets/Scripts/ARUI/UIComponents/DwellButton.cs
+++ b/unity/ARUI/Assets/Scripts/ARUI/UIComponents/DwellButton.cs
@@ -2,7 +2,7 @@
 using Microsoft.MixedReality.Toolkit.Input;
 using System;
 using System.Collections;
-using System.Diagnostics.Eventing.Reader;
+//using System.Diagnostics.Eventing.Reader;
 using UnityEngine;
 using UnityEngine.Events;
 using UnityEngine.EventSystems;

--- a/unity/ARUI/Assets/Scripts/ARUI/ViewManagement/VMNonControllable.cs
+++ b/unity/ARUI/Assets/Scripts/ARUI/ViewManagement/VMNonControllable.cs
@@ -2,7 +2,7 @@ using Microsoft.MixedReality.Toolkit.Input;
 using Microsoft.MixedReality.Toolkit.UI;
 using Newtonsoft.Json.Bson;
 using System.Collections.Generic;
-using System.Runtime.Remoting.Messaging;
+//using System.Runtime.Remoting.Messaging;
 using UnityEngine;
 
 public class VMNonControllable : VMObject

--- a/unity/ARUI/ProjectSettings/ProjectSettings.asset
+++ b/unity/ARUI/ProjectSettings/ProjectSettings.asset
@@ -705,7 +705,8 @@ PlayerSettings:
   gcIncremental: 1
   assemblyVersionValidation: 1
   gcWBarrierValidation: 0
-  apiCompatibilityLevelPerPlatform: {}
+  apiCompatibilityLevelPerPlatform:
+    WSA: 3
   m_RenderingPath: 1
   m_MobileRenderingPath: 1
   metroPackageName: Test


### PR DESCRIPTION
I needed to update software packages on my Windows machine, leading me to make sure I could still build a package. I found some updates to the README and a few other things:
* Update to .Net API Level 4.x (defaulted to .Net 2.0 standard). I thought it might fix the following but no dice.
* Found that there were a few lines in CU scripts that were causing script compilation errors. I'm not sure if these are necessary, but I was able to export and build with them commented out. @ovenmitt please let me know if those include lines are indeed required and I can retract that commit. I'm just not sure how to proceed with my script compilation error with them there.