### PR TITLE
Use `python3` in Dockerfile commands instead of `python`

### DIFF
--- a/docker/workspace-build/Dockerfile
+++ b/docker/workspace-build/Dockerfile
@@ -90,7 +90,7 @@ RUN apt-get -y update \
 COPY poetry.lock pyproject.toml docker/workspace_build_pydep_install.sh "${ANGEL_WORKSPACE_DIR}"/
 RUN cd "${ANGEL_WORKSPACE_DIR}" \
  && "${ANGEL_WORKSPACE_DIR}/workspace_build_pydep_install.sh"
-RUN python -m nltk.downloader punkt
+RUN python3 -m nltk.downloader punkt
 
 # Build the angel_system python package
 # * This is intentionally separated from the above dep installation so as to


### PR DESCRIPTION
@mattbrown11 for your situational awareness.