### PR TITLE
Update ROS bridge to support Depth AHAT

### DIFF
--- a/ros/angel_system_nodes/angel_system_nodes/hl2ss_ros_bridge.py
+++ b/ros/angel_system_nodes/angel_system_nodes/hl2ss_ros_bridge.py
@@ -22,8 +22,6 @@ from angel_msgs.msg import (
     HeadsetAudioData,
     HeadsetPoseData,
     SpatialMesh,
-    # TODO: Is a message for depth AHAT needed here? Or from sensor_msgs?
-    # Currently re-using Image message
 )
 from angel_utils import declare_and_get_parameters, RateTracker
 from angel_utils.hand import JOINT_LIST

--- a/ros/angel_system_nodes/angel_system_nodes/hl2ss_ros_bridge.py
+++ b/ros/angel_system_nodes/angel_system_nodes/hl2ss_ros_bridge.py
@@ -179,7 +179,7 @@ class HL2SSROSBridge(Node):
             self._sm_thread.start()
         if self._rm_depth_AHAT_topic != DISABLE_TOPIC_STR:
             # Create frame publisher
-            self.ros_frame_publisher = self.create_publisher(
+            self.ros_depth_ahat_publisher = self.create_publisher(
                 Image, self._rm_depth_AHAT_topic, 1
             )
             self.connect_hl2ss_rm_depth_ahat()
@@ -557,9 +557,8 @@ class HL2SSROSBridge(Node):
         """
         log = self.get_logger()
 
-        while self._rm_depth_ahat_active.wait(
-            0
-        ):  # will quickly return false if cleared.
+        # `.wait(0)` will quickly return false if cleared.
+        while self._rm_depth_ahat_active.wait(0):
             data = self.hl2ss_rm_depth_ahat_client.get_next_packet()
 
             log.debug(
@@ -585,7 +584,7 @@ class HL2SSROSBridge(Node):
                 return
 
             # Publish the RM Depth AHAT msg
-            self.ros_frame_publisher.publish(rm_depth_ahat_msg)
+            self.ros_depth_ahat_publisher.publish(rm_depth_ahat_msg)
 
             self._rm_depth_ahat_rate_tracker.tick()
             log.debug(

--- a/tmux/record/record_ros_bag.yml
+++ b/tmux/record/record_ros_bag.yml
@@ -73,6 +73,7 @@ windows:
             -p pv_height:=720
             -p pv_framerate:=30
             -p sm_freq:=5
+            -p rm_depth_AHAT:=disable
         # Visualize Images being output from the headset
         - rqt_pv_images: rqt -s rqt_image_view/ImageView
             --args ${ROS_NAMESPACE}/PVFramesBGR


### PR DESCRIPTION
Draft of work to add RM Depth AHAT support back in for data collection. Currently, there are a few unknowns that may be best discovered by testing with the HoloLens 2 directly. As of writing this PR message, there is some trouble running ARUI with the HoloLens 2 at KRS and using it for testing without crashing.