### PR TITLE
Generate a *single* random recipe order

### DIFF
--- a/angel-docker-build.sh
+++ b/angel-docker-build.sh
@@ -4,6 +4,10 @@
 #
 set -e
 SCRIPT_DIR="$(cd "$(dirname "${0}")" && pwd)"
+
+# source common functionalities
+. "${SCRIPT_DIR}/scripts/common.bash"
+
 pushd "$SCRIPT_DIR"
 
 function usage()
@@ -17,11 +21,6 @@ Options:
   -h | --help   Display this message.
   --force       Force image building regardless of workspace hygiene.f
 "
-}
-
-function log()
-{
-  >&2 echo "$@"
 }
 
 # Option parsing
@@ -88,7 +87,9 @@ then
   log "Forwarding to docker-compose: ${dc_forward_params[@]}"
 fi
 
-docker-compose \
+get_docker_compose_cmd DC_CMD
+
+"${DC_CMD[@]}" \
   --env-file "$SCRIPT_DIR"/docker/.env \
   -f "$SCRIPT_DIR"/docker/docker-compose.yml \
   --profile build-only \

--- a/angel-docker-pull.sh
+++ b/angel-docker-pull.sh
@@ -4,6 +4,10 @@
 #
 set -e
 SCRIPT_DIR="$(cd "$(dirname "${0}")" && pwd)"
+
+# source common functionalities
+. "${SCRIPT_DIR}/scripts/common.bash"
+
 pushd "$SCRIPT_DIR"
 
 function usage()
@@ -36,10 +40,12 @@ done
 if [[ "${#dc_forward_params[@]}" -gt 0 ]]
 then
   # shellcheck disable=SC2145
-  echo "Forwarding to docker-compose: ${dc_forward_params[@]}"
+  log "Forwarding to docker-compose: ${dc_forward_params[@]}"
 fi
 
-docker-compose \
+get_docker_compose_cmd DC_CMD
+
+"${DC_CMD[@]}" \
   --env-file "$SCRIPT_DIR"/docker/.env \
   -f "$SCRIPT_DIR"/docker/docker-compose.yml \
   --profile build-only \

--- a/angel-docker-push.sh
+++ b/angel-docker-push.sh
@@ -4,6 +4,10 @@
 #
 set -e
 SCRIPT_DIR="$(cd "$(dirname "${0}")" && pwd)"
+
+# source common functionalities
+. "${SCRIPT_DIR}/scripts/common.bash"
+
 pushd "$SCRIPT_DIR"
 
 function usage()
@@ -36,10 +40,12 @@ done
 if [[ "${#dc_forward_params[@]}" -gt 0 ]]
 then
   # shellcheck disable=SC2145
-  echo "Forwarding to docker-compose: ${dc_forward_params[@]}"
+  log "Forwarding to docker-compose: ${dc_forward_params[@]}"
 fi
 
-docker-compose \
+get_docker_compose_cmd DC_CMD
+
+"${DC_CMD[@]}" \
   --env-file "$SCRIPT_DIR"/docker/.env \
   -f "$SCRIPT_DIR"/docker/docker-compose.yml \
   --profile build-only \

--- a/angel-workspace-shell.sh
+++ b/angel-workspace-shell.sh
@@ -5,6 +5,9 @@
 set -e
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
+# source common functionalities
+. "${SCRIPT_DIR}/scripts/common.bash"
+
 DEFAULT_SERVICE_NAME="workspace-shell-dev-gpu"
 
 function usage()
@@ -27,11 +30,6 @@ Options:
                                 invocation of workspace products.
   -s | --service=SERVICE_NAME   Explicitly use the provide service.
 "
-}
-
-function log()
-{
-  >&2 echo "$@"
 }
 
 # Option parsing
@@ -102,8 +100,10 @@ else
   "
 fi
 
+get_docker_compose_cmd DC_CMD
+
 set +e
-docker-compose \
+"${DC_CMD[@]}" \
   --env-file "$ENV_FILE" \
   -f "$SCRIPT_DIR"/docker/docker-compose.yml \
   run --rm \

--- a/scripts/common.bash
+++ b/scripts/common.bash
@@ -1,0 +1,46 @@
+# Common functions and definitions for use in bash scripts.
+
+
+# Logging function to output strings to STDERR.
+function log()
+{
+  >&2 echo "$@"
+}
+
+
+# Define to a variable of the given name an array composed of the appropriate
+# CLI arguments to invoke docker compose for the current system, if able at
+# all.
+#
+# If a docker compose tool cannot be identified, this function returns code 1.
+#
+# This should generally be called like:
+#     get_docker_compose_cmd DC_CMD
+# Which results in "DC_CMD" being defined as an array in the calling context,
+# viewable like:
+#     echo "${DC_CMD[@]}"
+#
+function get_docker_compose_cmd()
+{
+  EXPORT_VAR_NAME="$1"
+  if [[ -z "$EXPORT_VAR_NAME" ]]
+  then
+    log "[ERROR] No export variable name provided as the first positional argument."
+    return 1
+  fi
+  # Check for v1 docker-compose tool, otherwise try to make use of v2
+  # docker-compose plugin
+  if ( command -v docker-compose >/dev/null 2>&1 )
+  then
+    log "[INFO] Using v1 docker-compose python tool"
+    EVAL_STR="${EXPORT_VAR_NAME}=( docker-compose )"
+  elif ( docker compose >/dev/null 2>&1 )
+  then
+    log "[INFO] Using v2 docker compose plugin"
+    EVAL_STR="${EXPORT_VAR_NAME}=( docker compose )"
+  else
+    log "[ERROR] No docker compose functionality found on the system."
+    return 1
+  fi
+  eval "${EVAL_STR}"
+}


### PR DESCRIPTION
I understand that this is someone in conflict with #282, however this should be a more preferrable way to generate a random recipe ordering as we would no longer be generating a fully exhaustive list of *all* permutations to then only select a few. There is a trivial path from this version to the features that are also added to #282.

This branch also includes a few fixes and generalizations of scripting functionality to support the docker-compose-plugin which has a different invocation pattern (`docker compose ...` as opposed to `docker-compose ...`). I needed to do this as my previous installation of python `docker`/`docker-compose` packages were having linking issues with docker/openssl.