### PR TITLE
Change to Cyclone using Loopback interface

### DIFF
--- a/docker/.env
+++ b/docker/.env
@@ -22,6 +22,11 @@ ROS_LOCALHOST_ONLY=1
 # option for the `./angel-workspace-shell.sh` script.
 #SETUP_WORKSPACE_INSTALL=true
 
+# Set which DDS middleware to be used.
+#RMW_IMPLEMENTATION=rmw_fastrtps_cpp
+RMW_IMPLEMENTATION=rmw_cyclonedds_cpp
+
 # Uncomment and specify an network interface to specify which to use at runtime
 # loopback interface
+# * This in combination
 CYCLONE_DDS_INTERFACE=lo

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -85,9 +85,10 @@ services:
       - ${XAUTH_FILEPATH}:/tmp/.docker.xauth
     environment:
       HISTFILE: ${ANGEL_WORKSPACE_DIR}/stuff/bash_history
-      CYCLONE_DDS_INTERFACE:  # from .env file or parent environment
       SETUP_WORKSPACE_INSTALL:  # from .env file or parent environment
       ROS_LOCALHOST_ONLY:  # from .env file or parent environment
+      RMW_IMPLEMENTATION:  # from .env file or parent environment
+      CYCLONE_DDS_INTERFACE:  # from .env file or parent environment
       DISPLAY:  # pull from current environment
       XAUTHORITY: /tmp/.docker.xauth
       PYTHONDONTWRITEBYTECODE: 1  # Don't write .pyc files when in workspace
@@ -114,6 +115,7 @@ services:
     volumes:
       - /dev/shm:/dev/shm
     environment:
-      CYCLONE_DDS_INTERFACE:  # from .env file or parent environment
       ROS_LOCALHOST_ONLY:  # from .env file or parent environment
+      RMW_IMPLEMENTATION:  # from .env file or parent environment
+      CYCLONE_DDS_INTERFACE:  # from .env file or parent environment
       SETUP_WORKSPACE_INSTALL: 1  # yes, activate the workspace here

--- a/docker/fastrtps_profile.xml.tmpl
+++ b/docker/fastrtps_profile.xml.tmpl
@@ -5,7 +5,9 @@
     <publisher profile_name="default publisher profile" is_default_profile="true">
         <qos>
             <publishMode>
-                <kind>ASYNCHRONOUS</kind>
+                <kind>SYNCHRONOUS</kind>
+                <!-- Async mode seems to allow for "stalls" in some cases. -->
+                <!--<kind>ASYNCHRONOUS</kind>-->
             </publishMode>
         </qos>
         <historyMemoryPolicy>PREALLOCATED_WITH_REALLOC</historyMemoryPolicy>

--- a/docker/workspace_entrypoint.sh
+++ b/docker/workspace_entrypoint.sh
@@ -18,33 +18,4 @@ fi
 # Activate our workspace
 source "${ANGEL_WORKSPACE_DIR}/workspace_setenv.sh"
 
-# Report on ROS localhost only mode.
-if [[ "${ROS_LOCALHOST_ONLY}" -ne 0 ]]
-then
-  >&2 echo "[INFO] Setting ROS to localhost-only communication."
-else
-  >&2 echo "[INFO] ROS host communication unconstrained."
-fi
-
-# Configure RMW-specific configurations depending on what is set to be used.
-if [[ "${RMW_IMPLEMENTATION}" = "rmw_fastrtps_cpp" ]]
-then
-  >&2 echo "[INFO] RMW set to FastRTPS, generating config XML."
-  envsubst <"${SCRIPT_DIR}/fastrtps_profile.xml.tmpl" >"${SCRIPT_DIR}/fastrtps_profile.xml"
-  export FASTRTPS_DEFAULT_PROFILES_FILE="${SCRIPT_DIR}/fastrtps_profile.xml"
-  export RMW_FASTRTPS_USE_QOS_FROM_XML=1
-elif [[ "${RMW_IMPLEMENTATION}" = "rmw_cyclonedds_cpp" ]]
-then
-  >&2 echo "[INFO] RMW set to Cyclone DDS, generating config XML."
-  if [[ -z "$CYCLONE_DDS_INTERFACE" ]]
-  then
-    >&2 echo "[ERROR] Cyclone DDS RMW specified, but not interface specified in var CYCLONE_DDS_INTERFACE."
-    exit 1
-  fi
-  envsubst <"${SCRIPT_DIR}/cyclonedds_profile.xml.tmpl" >"${SCRIPT_DIR}/cyclonedds_profile.xml"
-  export CYCLONEDDS_URI="file://${SCRIPT_DIR}/cyclonedds_profile.xml"
-else
-  >&2 echo "[INFO] No explicit RMW set, using stock defaults."
-fi
-
 exec "$@"

--- a/docker/workspace_setenv.sh
+++ b/docker/workspace_setenv.sh
@@ -1,9 +1,34 @@
 # This encapsulates environment setup that should be set for both build-time
 # and run-time.
 
-#export RMW_IMPLEMENTATION=rmw_fastrtps_cpp
+# Enable multicast flag on the loopback device (should always be present)
+ifconfig lo multicast
 
-# Set Cyclone DDS for middleware
-# * We were finding that this middleware was slow for local node connections
-#   that fastRTPS is more appropriate for which should be using shared memory.
-#export RMW_IMPLEMENTATION=rmw_cyclonedds_cpp
+# Report on ROS localhost only mode.
+if [[ "${ROS_LOCALHOST_ONLY}" -ne 0 ]]
+then
+  >&2 echo "[INFO] Setting ROS to localhost-only communication."
+else
+  >&2 echo "[INFO] ROS host communication unconstrained."
+fi
+
+# Configure RMW-specific configurations depending on what is set to be used.
+if [[ "${RMW_IMPLEMENTATION}" = "rmw_fastrtps_cpp" ]]
+then
+  >&2 echo "[INFO] RMW set to FastRTPS, generating config XML."
+  envsubst <"${SCRIPT_DIR}/fastrtps_profile.xml.tmpl" >"${SCRIPT_DIR}/fastrtps_profile.xml"
+  export FASTRTPS_DEFAULT_PROFILES_FILE="${SCRIPT_DIR}/fastrtps_profile.xml"
+  export RMW_FASTRTPS_USE_QOS_FROM_XML=1
+elif [[ "${RMW_IMPLEMENTATION}" = "rmw_cyclonedds_cpp" ]]
+then
+  >&2 echo "[INFO] RMW set to Cyclone DDS, generating config XML."
+  if [[ -z "$CYCLONE_DDS_INTERFACE" ]]
+  then
+    >&2 echo "[ERROR] Cyclone DDS RMW specified, but not interface specified in var CYCLONE_DDS_INTERFACE."
+    exit 1
+  fi
+  envsubst <"${SCRIPT_DIR}/cyclonedds_profile.xml.tmpl" >"${SCRIPT_DIR}/cyclonedds_profile.xml"
+  export CYCLONEDDS_URI="file://${SCRIPT_DIR}/cyclonedds_profile.xml"
+else
+  >&2 echo "[INFO] No explicit RMW set, using stock defaults."
+fi


### PR DESCRIPTION
Adding to workspace setenv a call to ifconfig that adds multicast to the loopback interface which should not be an issue on the systems relevant to immediate processing.