### PR TITLE
fix to granular_to_broad converions

### DIFF
--- a/angel_system/global_step_prediction/global_step_predictor.py
+++ b/angel_system/global_step_prediction/global_step_predictor.py
@@ -290,7 +290,7 @@ class GlobalStepPredictor:
         granular_step_4
         """
         lgspbs = np.array(tracker["last_granular_step_per_broad_step"])
-        return len(np.nonzero(fgspbs < granular_step)[0])
+        return len(np.nonzero(lgspbs < granular_step)[0])
 
     def get_unique(self, activity_ids):
         """
@@ -746,14 +746,14 @@ class GlobalStepPredictor:
         granular_step_to_activity_id = self.get_activity_per_granular_step(broad_steps)
         lgspbs = self.get_last_granular_step_per_broad_step(broad_steps)
 
-        def get_broad_step_from_granular_step(fgspbs, granular_step):
-            fgspbs = np.array(fgspbs)
-            return len(np.nonzero(fgspbs <= granular_step))
+        def get_broad_step_from_granular_step(lgspbs, granular_step):
+            lgspbs = np.array(lgspbs)
+            return len(np.nonzero(lgspbs <= granular_step))
 
         for activity_gt in activity_gts:
             # convert activity id to step id
             granular_step_id = granular_step_to_activity_id.index(activity_gt)
-            broad_step_id = get_broad_step_from_granular_step(fgspbs, granular_step_id)
+            broad_step_id = get_broad_step_from_granular_step(lgspbs, granular_step_id)
 
             granular_step_gts.append(granular_step_id)
             broad_step_gts.append(broad_step_id)

--- a/angel_system/global_step_prediction/global_step_predictor.py
+++ b/angel_system/global_step_prediction/global_step_predictor.py
@@ -305,7 +305,7 @@ class GlobalStepPredictor:
 
     def get_last_granular_step_per_broad_step(self, steps):
         """
-        Get first substep index of each broad step.
+        Get last substep index of each broad step.
         Example: a recipe might have 8 succinct steps, with
         multiple activities per succinct step:
         step 0: background


### PR DESCRIPTION
An exciting fix!

The broad steps were being incremented from granular steps "a little late".

This is because an indexing tool I was using called "first_granular_step_per_broad_step" was actually the LAST granular step per broad step.

Example of the index:
```
 [0, 1, 3, 4, 6, 7, 8, 9, 11, 12, 14, 17, 18]
 ```
 granular step 3 = the LAST granular step of broad step 2 (so granular_step 2 is also part of broad_step 2). It was previously assumed to be the first granular step (so granular_step 2 was assumed to be part of step 1).
 
 We noticed latency in incrementing broad steps in the system. This will certainly improve that issue.