### PR TITLE
Fix docker .env file to use the latest tag again

### DIFF
--- a/docker/.env
+++ b/docker/.env
@@ -7,7 +7,7 @@ ROS_VERSION=iron
 ANGEL_WORKSPACE_DIR=/angel_workspace
 
 PTG_REGISTRY=gitlab.kitware.com:4567/ptg-angel/docker
-PTG_TAG=iron-upgrade
+PTG_TAG=latest
 
 # Directory for the workspace shell to mount files and directories into on the
 # host system. If a relative path, it will be interpreted as relative to the


### PR DESCRIPTION
Return setting the `PTG_TAG` to `latest` in the `docker/.env` file for default image building.