### PR TITLE
Reinstate bash code to generate xauth file for sharing with the container

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,12 +78,17 @@ Workspace root: `./ros/`
 System requirements
 * ansible
 * docker
-* docker-compose
+* (pip-installed) docker-compose
 
 Some files required from the `https://data.kitware.com` Girder service require
 authentication due to their protected nature.
 The environment variable `GIRDER_API_KEY` must be defined with a valid API key,
 otherwise an authentication token cannot be retrieved.
+
+We currently require a pip-installed `docker-compose` tool, as opposed to a
+system package-manager installed `docker-compose-plugin` package.
+The package manager docker plugin behaves a little differently that our current
+docker-compose configuration and scripting does not yet handle.
 
 ## Provision Files
 External large files should be provisioned by running the ansible tool:

--- a/angel-workspace-shell.sh
+++ b/angel-workspace-shell.sh
@@ -77,6 +77,9 @@ mkdir -p "${XAUTH_DIR}"
 # Exporting to be used in replacement in docker-compose file.
 XAUTH_FILEPATH="$(mktemp "${XAUTH_DIR}/local-XXXXXX.xauth")"
 export XAUTH_FILEPATH
+log "[INFO] Creating local xauth file: $XAUTH_FILEPATH"
+touch "$XAUTH_FILEPATH"
+xauth nlist "$DISPLAY" | sed -e 's/^..../ffff/' | xauth -f "$XAUTH_FILEPATH" nmerge -
 
 # Conditionally gather if jupyter is available in the current
 # environment and parameterize mounting it's runtime dir

--- a/tmux/demos/cooking/cooking-angel-system_from-old-bag.yml
+++ b/tmux/demos/cooking/cooking-angel-system_from-old-bag.yml
@@ -69,6 +69,11 @@ windows:
             -p image_topic:=PVFramesRGB
             -p output_topic:=PVFramesRGB_TS
 
+        # # Visualize RGB Images being output from the headset
+        # - rqt_rgb_images: rqt -s rqt_image_view/ImageView
+        #     --args ${ROS_NAMESPACE}/PVFramesBGR
+        #     --ros-args -p _image_transport:=raw
+
   - object_detector:
       layout: even-vertical
       panes:


### PR DESCRIPTION
For some reason this was removed in an earlier commit relating to adding jupyter notebook runtime mounting with no indication as to why. Interpreting this as a mistake as I can confirm that X-pass through graphics tools no longer work with the current setup, but renew working when adding back in proper temporary xauth files for the containers to use.