### PR TITLE
Update .env to supply innocuous default for XAUTH_FILEPATH

### DIFF
--- a/angel-docker-build.sh
+++ b/angel-docker-build.sh
@@ -19,7 +19,7 @@ Build the PTG ANGEL system docker container images.
 
 Options:
   -h | --help   Display this message.
-  --force       Force image building regardless of workspace hygiene.f
+  -f | --force  Force image building regardless of workspace hygiene.
 "
 }
 
@@ -32,7 +32,7 @@ do
       usage
       exit 0
       ;;
-    --force)
+    -f|--force)
       log "Forcing build regardless of workspace hygiene."
       shift
       FORCE_BUILD=1
@@ -113,4 +113,4 @@ get_docker_compose_cmd DC_CMD
   --env-file "$SCRIPT_DIR"/docker/.env \
   -f "$SCRIPT_DIR"/docker/docker-compose.yml \
   --profile build-only \
-  build "$@"
+  build "${dc_forward_params[@]}" "$@"

--- a/docker/.env
+++ b/docker/.env
@@ -32,3 +32,10 @@ RMW_IMPLEMENTATION=rmw_cyclonedds_cpp
 
 # This must specify the network interface for CycloneDDS to use.
 CYCLONE_DDS_INTERFACE=lo
+
+# Starting with the docker compose plugin (v2), the whole compose file will be
+# validated, even for services not being run. This provides a valid "default"
+# path to cause validation to succeed. This variable should be overridden when
+# attempting to actually run a service that makes use of this variable.
+# Path considered relative to where the docker-compose file is located.
+XAUTH_FILEPATH=../.container_xauth/.placeholder


### PR DESCRIPTION
Fix build script to *actually* pass forward extra args to docker compose build command.