### PR TITLE
Add a script to provision down files in a, hopefully, common fashion

### DIFF
--- a/angel-provision-files.sh
+++ b/angel-provision-files.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+#
+# Standard method of invoking ansible based file provisioning.
+#
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+pushd "${SCRIPT_DIR}"
+
+ansible-playbook \
+  -i ansible/hosts.yml \
+  -e ansible_python_interpreter=python3 \
+  ansible/provision_files.yml


### PR DESCRIPTION
This also includes a `-e` environment parameter that should normalize that the `python3` executable should be used on the target host. This is due to some recent issues with some other version of python being used incorrectly that is not fully understood yet (given lack of attention time).