### PR TITLE
Add reset/start/stop System command behaviors and response by GSP Task Monitor

### DIFF
--- a/angel_system/global_step_prediction/global_step_predictor.py
+++ b/angel_system/global_step_prediction/global_step_predictor.py
@@ -358,6 +358,7 @@ class GlobalStepPredictor:
         print(f"RESETTING tracker {tracker_ind}")
         self.trackers[tracker_ind]["current_broad_step"] = 0
         self.trackers[tracker_ind]["current_granular_step"] = 0
+        self.trackers[tracker_ind]["active"] = True
         self.tracker_resets.append(self.trackers[tracker_ind]["recipe"])
 
     def granular_to_broad_step(self, tracker, granular_step):

--- a/angel_system/global_step_prediction/global_step_predictor.py
+++ b/angel_system/global_step_prediction/global_step_predictor.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from typing import Any, Dict, List
 
 import yaml
 import seaborn as sn
@@ -77,7 +78,7 @@ class GlobalStepPredictor:
         self.recipe_configs = recipe_config_dict
 
         # Array of tracker dicts
-        self.trackers = []
+        self.trackers: List[Dict[str, Any]] = []
         for recipe in recipe_types:
             self.initialize_new_recipe_tracker(recipe)
 

--- a/config/tasks/cooking/multi-task-config.yaml
+++ b/config/tasks/cooking/multi-task-config.yaml
@@ -13,21 +13,21 @@ tasks:
   #   (i.e. relative to $(ANGEL_WORKSPACE)).
   - id: 0
     label: "Coffee"
-    config_file: "./config/tasks/recipe_coffee.yaml"
+    config_file: "./config/tasks/cooking/recipe_coffee.yaml"
     active: true
   - id: 1
     label: "Tea"
-    config_file: "./config/tasks/recipe_tea.yaml"
+    config_file: "./config/tasks/cooking/recipe_tea.yaml"
     active: true
   - id: 2
     label: "Pinwheel"
-    config_file: "./config/tasks/recipe_pinwheel.yaml"
+    config_file: "./config/tasks/cooking/recipe_pinwheel.yaml"
     active: true
   - id: 3
     label: "Oatmeal"
-    config_file: "./config/tasks/recipe_oatmeal.yaml"
+    config_file: "./config/tasks/cooking/recipe_oatmeal.yaml"
     active: true
   - id: 4
     label: "Dessert Quesadilla"
-    config_file: "./config/tasks/recipe_dessertquesadilla.yaml"
+    config_file: "./config/tasks/cooking/recipe_dessertquesadilla.yaml"
     active: true

--- a/ros/angel_msgs/msg/SystemCommands.msg
+++ b/ros/angel_msgs/msg/SystemCommands.msg
@@ -11,6 +11,9 @@
 ##############################
 # Task Monitor commands
 
+# Reset the whole task monitor state.
+bool reset_monitor_state
+
 # Index of the task to which the commands here pertain.
 int8 task_index
 # Reset the referenced task's state and start over from the beginning.

--- a/ros/angel_msgs/msg/SystemCommands.msg
+++ b/ros/angel_msgs/msg/SystemCommands.msg
@@ -14,6 +14,9 @@
 # Reset the whole task monitor state.
 bool reset_monitor_state
 
+# Toggle the state of the monitor's "pause" command.
+bool toggle_monitor_pause
+
 # Index of the task to which the commands here pertain.
 int8 task_index
 # Reset the referenced task's state and start over from the beginning.

--- a/ros/angel_msgs/msg/SystemCommands.msg
+++ b/ros/angel_msgs/msg/SystemCommands.msg
@@ -8,8 +8,15 @@
 # received message instance.
 #
 
+##############################
 # Task Monitor commands
+
+# Index of the task to which the commands here pertain.
 int8 task_index
-bool reset_current_task
+# Reset the referenced task's state and start over from the beginning.
+# TODO: This is currently unused.
+bool reset_task
+# Revert our step tracking for the referenced task to the previous step.
 bool previous_step
+# Progress our step tracking for the referenced task to the next step.
 bool next_step

--- a/ros/angel_system_nodes/angel_system_nodes/task_monitoring/keyboard_to_sys_cmd.py
+++ b/ros/angel_system_nodes/angel_system_nodes/task_monitoring/keyboard_to_sys_cmd.py
@@ -61,6 +61,10 @@ class KeyboardToSystemCommands(Node):
             log.info("Registering command to reset task monitor")
             return self.publish_monitor_reset
 
+        def for_pause_toggle():
+            log.info("Registering command to toggle task monitor pause")
+            return self.publish_pause_toggle
+
         with keyboard.GlobalHotKeys(
             {
                 "<ctrl>+<shift>+!": for_task_direction(0, False),
@@ -74,6 +78,7 @@ class KeyboardToSystemCommands(Node):
                 "<ctrl>+<shift>+(": for_task_direction(4, False),
                 "<ctrl>+<shift>+)": for_task_direction(4, True),
                 "<ctrl>+<shift>+R": for_monitor_reset(),
+                "<ctrl>+<shift>+P": for_pause_toggle(),
             }
         ) as h:
             h.join()
@@ -105,6 +110,16 @@ class KeyboardToSystemCommands(Node):
         msg = SystemCommands()
         msg.reset_monitor_state = True
         log.info("Publishing command to reset monitor")
+        self._sys_cmd_publisher.publish(msg)
+
+    def publish_pause_toggle(self) -> None:
+        """
+        Publishes a SystemCommand message indicating a pause toggle.
+        """
+        log = self.get_logger()
+        msg = SystemCommands()
+        msg.toggle_monitor_pause = True
+        log.info("Publishing command to toggle pause")
         self._sys_cmd_publisher.publish(msg)
 
 

--- a/ros/angel_system_nodes/angel_system_nodes/task_monitoring/keyboard_to_sys_cmd.py
+++ b/ros/angel_system_nodes/angel_system_nodes/task_monitoring/keyboard_to_sys_cmd.py
@@ -55,7 +55,11 @@ class KeyboardToSystemCommands(Node):
                 f"Registering command to move task {t_id} "
                 f"{'forward' if forward else 'backward'}"
             )
-            return lambda: self.publish_sys_cmd(t_id, forward)
+            return lambda: self.publish_step_change(t_id, forward)
+
+        def for_monitor_reset():
+            log.info("Registering command to reset task monitor")
+            return self.publish_monitor_reset
 
         with keyboard.GlobalHotKeys(
             {
@@ -69,11 +73,12 @@ class KeyboardToSystemCommands(Node):
                 "<ctrl>+<shift>+*": for_task_direction(3, True),
                 "<ctrl>+<shift>+(": for_task_direction(4, False),
                 "<ctrl>+<shift>+)": for_task_direction(4, True),
+                "<ctrl>+<shift>+R": for_monitor_reset(),
             }
         ) as h:
             h.join()
 
-    def publish_sys_cmd(self, task_id: int, forward: bool) -> None:
+    def publish_step_change(self, task_id: int, forward: bool) -> None:
         """
         Publishes the SystemCommand message to the configured ROS topic.
         """
@@ -90,6 +95,16 @@ class KeyboardToSystemCommands(Node):
             cmd_str = "backward"
 
         log.info(f"Publishing command for task {task_id} to move {cmd_str}")
+        self._sys_cmd_publisher.publish(msg)
+
+    def publish_monitor_reset(self) -> None:
+        """
+        Publishes a SystemCommand message indicating a whole monitor reset
+        """
+        log = self.get_logger()
+        msg = SystemCommands()
+        msg.reset_monitor_state = True
+        log.info("Publishing command to reset monitor")
         self._sys_cmd_publisher.publish(msg)
 
 

--- a/tmux/demos/medical/Kitware-R18-Zed2i.yml
+++ b/tmux/demos/medical/Kitware-R18-Zed2i.yml
@@ -113,6 +113,9 @@ windows:
   - task_monitor:
       layout: even-vertical
       panes:
+        - keyboard_to_sys_cmd: ros2 run angel_system_nodes keyboard_to_sys_cmd --ros-args
+            -r __ns:=${ROS_NAMESPACE}
+            -p system_command_topic:=SystemCommands
         - gsp: ros2 run angel_system_nodes global_step_predictor --ros-args
             -r __ns:=${ROS_NAMESPACE}
             -p config_file:=${CONFIG_DIR}/tasks/medical/multi-task-config-medical-r18.yaml
@@ -128,6 +131,7 @@ windows:
             -p threshold_frame_count_weak:=3
             -p step_mode:=granular
             -p query_task_graph_topic:=query_task_graph
+            -p start_paused:=true
         - echo: sleep 0.5 && ros2 topic echo --no-arr "${ROS_NAMESPACE}/TaskUpdates"
 
   - engineering-ui:


### PR DESCRIPTION
Currently have decided that the GSP Node should allow step-change/reset commands while in a paused state.


SystemCommands message changes:
* Added whole-monitor restart SystemCommands slot.
* Added toggle for monitor pause state.

GSP Node changes:
* Added parameter to dictate whether the node starts in a "paused" state or not. Defaults to current behavior of being "active" from the start.
* Modularized (re)loading of the GSP instance.
* Added handling of a SystemCommands message with a reset_monitor_state toggle. Mutually exclusive with a step change request in the same message. Resets all active tasks.
* Added handling of a SystemCommands message with a toggle_monitor_pause toggle.

Keyboard listener changes:
* Added Ctrl-Shift-R and Ctrl-Shift-P keyboard listeners to restart and toggle the paused state.