### PR TITLE
Dev/camera metadata

### DIFF
--- a/ros/angel_system_nodes/angel_system_nodes/activity_classification/activity_classifier_tcn.py
+++ b/ros/angel_system_nodes/angel_system_nodes/activity_classification/activity_classifier_tcn.py
@@ -29,6 +29,7 @@ from tcn_hpl.data.frame_data import (
     FramePoses,
 )
 from tcn_hpl.models.ptg_module import PTGLitModule
+from sensor_msgs.msg import CameraInfo
 
 from angel_system.activity_classification.tcn_hpl.predict import (
     ResultsCollector,
@@ -48,8 +49,8 @@ from angel_utils.activity_classification import InputWindow, InputBuffer
 from angel_utils.conversion import time_to_int
 
 
-# Input ROS topic for RGB Image Timestamps
-PARAM_IMG_TS_TOPIC = "image_ts_topic"
+# Input ROS topic for RGB Image Metadata
+PARAM_IMG_MD_TOPIC = "image_md_topic"
 # Input ROS topic for object detections.
 PARAM_DET_TOPIC = "det_topic"
 # Output ROS topic for activity classifications.
@@ -66,10 +67,6 @@ PARAM_MODEL_CONFIG = "model_config"
 PARAM_MODEL_DEVICE = "model_device"
 # Maximum amount of data we will buffer in seconds.
 PARAM_BUFFER_MAX_SIZE_SECONDS = "buffer_max_size_seconds"
-# Width in pixels of the imagery that object detections were predicted from.
-PARAM_IMAGE_PIX_WIDTH = "image_pix_width"
-# Height in pixels of the imagery that object detections were predicted from.
-PARAM_IMAGE_PIX_HEIGHT = "image_pix_height"
 # Runtime thread checkin heartbeat interval in seconds.
 PARAM_RT_HEARTBEAT = "rt_thread_heartbeat"
 # Where we should output an MS-COCO file with our activity predictions in it
@@ -140,7 +137,7 @@ class ActivityClassifierTCN(Node):
         param_values = declare_and_get_parameters(
             self,
             [
-                (PARAM_IMG_TS_TOPIC,),
+                (PARAM_IMG_MD_TOPIC,),
                 (PARAM_DET_TOPIC,),
                 (PARAM_POSE_TOPIC,),
                 (PARAM_ACT_TOPIC,),
@@ -149,8 +146,6 @@ class ActivityClassifierTCN(Node):
                 (PARAM_MODEL_CONFIG,),
                 (PARAM_MODEL_DEVICE, "cuda"),
                 (PARAM_BUFFER_MAX_SIZE_SECONDS, 15),
-                (PARAM_IMAGE_PIX_WIDTH, 1280),
-                (PARAM_IMAGE_PIX_HEIGHT, 720),
                 (PARAM_RT_HEARTBEAT, 0.1),
                 (PARAM_OUTPUT_COCO_FILEPATH, ""),
                 (PARAM_INPUT_COCO_FILEPATH, ""),
@@ -161,7 +156,7 @@ class ActivityClassifierTCN(Node):
                 (PARAM_DEBUG_FILE, ""),
             ],
         )
-        self._img_ts_topic = param_values[PARAM_IMG_TS_TOPIC]
+        self._img_md_topic = param_values[PARAM_IMG_MD_TOPIC]
         self._det_topic = param_values[PARAM_DET_TOPIC]
 
         self._pose_topic = param_values[PARAM_POSE_TOPIC]
@@ -169,8 +164,8 @@ class ActivityClassifierTCN(Node):
 
         self._act_topic = param_values[PARAM_ACT_TOPIC]
         self._act_config = load_activity_label_set(param_values[PARAM_ACT_CONFIG_FILE])
-        self._img_pix_width = int(param_values[PARAM_IMAGE_PIX_WIDTH])
-        self._img_pix_height = int(param_values[PARAM_IMAGE_PIX_HEIGHT])
+        self._img_pix_width = 1280  # default size - replaced by metadata topic
+        self._img_pix_height = 720
         self._enable_trace_logging = param_values[PARAM_TIME_TRACE_LOGGING]
 
         self._window_lead_with_objects = param_values[PARAM_WINDOW_LEADS_WITH_OBJECTS]
@@ -261,9 +256,9 @@ class ActivityClassifierTCN(Node):
         # runtime-thread allocation.
         # This is intentionally before runtime-loop initialization.
         self._img_ts_subscriber = self.create_subscription(
-            Time,
-            self._img_ts_topic,
-            self.img_ts_callback,
+            CameraInfo,
+            self._img_md_topic,
+            self.img_md_callback,
             1,
             callback_group=MutuallyExclusiveCallbackGroup(),
         )
@@ -392,7 +387,13 @@ class ActivityClassifierTCN(Node):
             log.info(f"Queuing from COCO: n_dets={n_dets}, image_ts={image_ts}")
             self.det_callback(det_msg)
             # self.pose_callback(det_msg)
-            self.img_ts_callback(image_ts)
+            new_msg = CameraInfo()
+            new_msg.header.stamp = image_ts
+            # set the image width and height from the image in the dataset
+            img = dset.imgs[image_id]
+            new_msg.width = img.get("width")
+            new_msg.height = img.get("height")
+            self.img_md_callback(new_msg)
 
             # Wait until `image_ts` was considered in the runtime loop before
             # proceeding into the next iteration.
@@ -407,17 +408,23 @@ class ActivityClassifierTCN(Node):
         log.info("Completed COCO file object yielding")
         self._rt_active.clear()
 
-    def img_ts_callback(self, msg: Time) -> None:
+    def img_md_callback(self, msg: CameraInfo) -> None:
         """
         Capture a detection source image timestamp message.
         """
+        # set the image width and height
+        self._img_pix_width = msg.width
+        self._img_pix_height = msg.height
+
         log = self.get_logger()
         self._current_frame_number += 1
         if self.rt_alive() and self._buffer.queue_image(
-            None, msg, self._current_frame_number
+            None, msg.header.stamp, self._current_frame_number
         ):
             if self._enable_trace_logging:
-                log.info(f"Queueing image TS {msg} frame {self._current_frame_number}")
+                log.info(
+                    f"Queueing image TS {msg.header.stamp} frame {self._current_frame_number}"
+                )
 
             # If we are configured to prefer the latest image received as the
             # latest image in the processing window, indicate the runtime upon

--- a/ros/angel_system_nodes/angel_system_nodes/data_publishers/image_metadata_relay.py
+++ b/ros/angel_system_nodes/angel_system_nodes/data_publishers/image_metadata_relay.py
@@ -3,10 +3,9 @@ Simple node to take an image, extract its header's timestamp and forward just
 that to the configured topic.
 """
 
-from builtin_interfaces.msg import Time
 from rclpy.callback_groups import MutuallyExclusiveCallbackGroup
 from rclpy.node import Node
-from sensor_msgs.msg import Image
+from sensor_msgs.msg import Image, CameraInfo
 
 from angel_utils import declare_and_get_parameters, RateTracker
 from angel_utils import make_default_main
@@ -16,7 +15,7 @@ PARAM_INPUT_TOPIC = "image_topic"
 PARAM_OUTPUT_TOPIC = "output_topic"
 
 
-class ImageTimestampRelay(Node):
+class ImageMetadataRelay(Node):
     def __init__(self):
         super().__init__(self.__class__.__name__)
 
@@ -38,22 +37,28 @@ class ImageTimestampRelay(Node):
             callback_group=MutuallyExclusiveCallbackGroup(),
         )
         self._pub = self.create_publisher(
-            Time,
+            CameraInfo,
             param_values[PARAM_OUTPUT_TOPIC],
             1,
             callback_group=MutuallyExclusiveCallbackGroup(),
         )
 
     def input_callback(self, msg: Image) -> None:
-        self._pub.publish(msg.header.stamp)
+        new_msg = CameraInfo()
+        new_msg.header = msg.header
+        new_msg.height = msg.height
+        new_msg.width = msg.width
+
+        self._pub.publish(new_msg)
         self._rate_tracker.tick()
         self.get_logger().info(
-            f"[input_callback] Forwarded image with TS={msg.header.stamp}, "
+            f"[input_callback] CameraInfo message with TS={msg.header.stamp}, "
+            f"image size {msg.width}x{msg.height}, "
             f"rate={self._rate_tracker.get_rate_avg()} Hz",
         )
 
 
-main = make_default_main(ImageTimestampRelay, multithreaded_executor=2)
+main = make_default_main(ImageMetadataRelay, multithreaded_executor=2)
 
 
 if __name__ == "__main__":

--- a/ros/angel_system_nodes/setup.py
+++ b/ros/angel_system_nodes/setup.py
@@ -34,7 +34,7 @@ setup(
             "frame_publisher = angel_system_nodes.data_publishers.ros_publisher:main",
             "generate_images = angel_system_nodes.data_publishers.generate_images:main",
             "hl2ss_ros_bridge = angel_system_nodes.data_publishers.hl2ss_ros_bridge:main",
-            "image_timestamp_relay = angel_system_nodes.data_publishers.image_timestamp_relay:main",
+            "image_metadata_relay = angel_system_nodes.data_publishers.image_metadata_relay:main",
             "redis_ros_bridge = angel_system_nodes.data_publishers.redis_ros_bridge:main",
             # Evaluation Components
             "eval_2_logger = angel_system_nodes.eval.mitll_eval_2_logger:main",

--- a/tmux/demos/medical/Kitware-M2.yml
+++ b/tmux/demos/medical/Kitware-M2.yml
@@ -58,13 +58,13 @@ windows:
       panes:
         # Read sensor input from bag file.
         - sensor_input: echo ros2 bag play ${ANGEL_WORKSPACE_DIR}/ros_bags/...
-        - run_image_timestamp: ros2 run angel_system_nodes image_timestamp_relay --ros-args
+        - run_image_metadata: ros2 run angel_system_nodes image_metadata_relay --ros-args
             -r __ns:=${ROS_NAMESPACE}
             -p image_topic:=PVFramesBGR
-            -p output_topic:=PVFramesBGR_ts
+            -p output_topic:=PVFramesBGR_md
         - run_latency_node: ros2 run angel_system_nodes latency_tracker --ros-args
             -r __ns:=${ROS_NAMESPACE}
-            -p image_ts_topic:=PVFramesBGR_ts
+            -p image_md_topic:=PVFramesBGR_md
             -p det_topic:=ObjectDetections2d
             -p pose_topic:=PatientPose
             -p activity_topic:=activity_topic
@@ -78,7 +78,7 @@ windows:
 #            -r __ns:=${ROS_NAMESPACE}
 #            -p ip_addr:=${HL2_IP}
 #            -p image_topic:=PVFramesBGR
-#            -p image_ts_topic:=PVFramesBGR_ts
+#            -p image_md_topic:=PVFramesBGR_md
 #            -p hand_pose_topic:=disable
 #            -p audio_topic:=disable
 #            -p sm_topic:=disable
@@ -115,7 +115,7 @@ windows:
 
   - activity_classifier: ros2 run angel_system_nodes activity_classifier_tcn --ros-args
       -r __ns:=${ROS_NAMESPACE}
-      -p image_ts_topic:=PVFramesBGR_ts
+      -p image_md_topic:=PVFramesBGR_md
       -p det_topic:=ObjectDetections2d
       -p pose_topic:=PatientPose
       -p activity_config_file:=${CONFIG_DIR}/activity_labels/medical/m2.yaml

--- a/tmux/demos/medical/Kitware-R18.yml
+++ b/tmux/demos/medical/Kitware-R18.yml
@@ -60,13 +60,13 @@ windows:
         # May have to use: --remap /kitware/image_0:=/kitware/PVFramesBGR
 #        - sensor_input: echo ros2 bag play ${ANGEL_WORKSPACE_DIR}/ros_bags/rosbag2-bbn_lab_data-r18-positive-seal_videos-seal_2-TEST_SET/
         - sensor_input: echo ros2 bag play ${ANGEL_WORKSPACE_DIR}/ros_bags/rosbag2-bbn_lab_data-r18-positive-30424_NE_recordings-R18_5-TEST_SET/
-        - run_image_timestamp: ros2 run angel_system_nodes image_timestamp_relay --ros-args
+        - run_image_metadata: ros2 run angel_system_nodes image_metadata_relay --ros-args
             -r __ns:=${ROS_NAMESPACE}
             -p image_topic:=PVFramesBGR
-            -p output_topic:=PVFramesBGR_ts
+            -p output_topic:=PVFramesBGR_md
         - run_latency_node: ros2 run angel_system_nodes latency_tracker --ros-args
             -r __ns:=${ROS_NAMESPACE}
-            -p image_ts_topic:=PVFramesBGR_ts
+            -p image_md_topic:=PVFramesBGR_md
             -p det_topic:=ObjectDetections2d
             -p pose_topic:=PatientPose
             -p activity_topic:=activity_topic
@@ -80,7 +80,7 @@ windows:
 #            -r __ns:=${ROS_NAMESPACE}
 #            -p ip_addr:=${HL2_IP}
 #            -p image_topic:=PVFramesBGR
-#            -p image_ts_topic:=PVFramesBGR_TS
+#            -p image_md_topic:=PVFramesBGR_md
 #            -p hand_pose_topic:=disable
 #            -p audio_topic:=HeadsetAudioData
 #            -p sm_topic:=disable
@@ -96,7 +96,7 @@ windows:
 #            -p ROS_IP:=0.0.0.0
 #        - run_latency_node: ros2 run angel_system_nodes latency_tracker --ros-args
 #            -r __ns:=${ROS_NAMESPACE}
-#            -p image_ts_topic:=PVFramesBGR_ts
+#            -p image_md_topic:=PVFramesBGR_md
 #            -p det_topic:=ObjectDetections2d
 #            -p pose_topic:=PatientPose
 #            -p activity_topic:=activity_topic
@@ -104,7 +104,7 @@ windows:
 
   - activity_classifier: ros2 run angel_system_nodes activity_classifier_tcn --ros-args
       -r __ns:=${ROS_NAMESPACE}
-      -p image_ts_topic:=PVFramesBGR_ts
+      -p image_md_topic:=PVFramesBGR_md
       -p det_topic:=ObjectDetections2d
       -p pose_topic:=PatientPose
       -p activity_config_file:=${CONFIG_DIR}/activity_labels/medical/r18.yaml

--- a/tmux/demos/medical/old/Kitware-M3.yml
+++ b/tmux/demos/medical/old/Kitware-M3.yml
@@ -58,12 +58,12 @@ windows:
       panes:
         # Read sensor input from bag file.
         - sensor_input: echo ros2 bag play ${ANGEL_WORKSPACE_DIR}/ros_bags/...
-        - run_image_timestamp: ros2 run angel_system_nodes image_timestamp_relay --ros-args
+        - run_image_metadata: ros2 run angel_system_nodes image_metadata_relay --ros-args
             -r __ns:=${ROS_NAMESPACE}
             -p image_topic:=PVFramesBGR
-            -p output_topic:=PVFramesBGR_ts
+            -p output_topic:=PVFramesBGR_md
         - run_latency_node: ros2 run angel_system_nodes latency_tracker --ros-args
-            -r __ns:=${ROS_NAMESPACE} -p image_ts_topic:=PVFramesBGR_ts
+            -r __ns:=${ROS_NAMESPACE} -p image_md_topic:=PVFramesBGR_md
             -p det_topic:=ObjectDetections2d -p pose_topic:=PatientPose
             -p activity_topic:=activity_topic -p latency_topic:=latency
 
@@ -75,7 +75,7 @@ windows:
 #            -r __ns:=${ROS_NAMESPACE}
 #            -p ip_addr:=${HL2_IP}
 #            -p image_topic:=PVFramesBGR
-#            -p image_ts_topic:=PVFramesBGR_ts
+#            -p image_md_topic:=PVFramesBGR_md
 #            -p hand_pose_topic:=disable
 #            -p audio_topic:=disable
 #            -p sm_topic:=disable
@@ -112,7 +112,7 @@ windows:
 
   - activity_classifier: ros2 run angel_system_nodes activity_classifier_tcn --ros-args
       -r __ns:=${ROS_NAMESPACE}
-      -p image_ts_topic:=PVFramesBGR_ts
+      -p image_md_topic:=PVFramesBGR_md
       -p det_topic:=ObjectDetections2d
       -p pose_topic:=PatientPose
       -p model_weights:=${MODEL_DIR}/activity_classifier/m3_tcn.ckpt

--- a/tmux/record/record_ros_bag.yml
+++ b/tmux/record/record_ros_bag.yml
@@ -65,7 +65,7 @@ windows:
             -r __ns:=${ROS_NAMESPACE}
             -p ip_addr:=${HL2_IP}
             -p image_topic:=PVFramesBGR
-            -p image_ts_topic:=PVFramesBGR_TS
+            -p image_md_topic:=PVFramesBGR_md
             -p hand_pose_topic:=HandJointPoseData
             -p audio_topic:=HeadsetAudioData
             -p sm_topic:=SpatialMapData


### PR DESCRIPTION
Convert the image_timestamp_relay to an image metadata topic.  Also does the same for the hl2ss node.  Adjusts down-stream processes like the latency node and activity_classifier_tcn node to consume the changed topic.  Drops the need for parameters into the tcn node for image width and height.